### PR TITLE
actionCacheFlush added

### DIFF
--- a/src/controllers/DefaultController.php
+++ b/src/controllers/DefaultController.php
@@ -162,9 +162,9 @@ class DefaultController extends Controller
     public function actionCacheFlush()
     {
         if (Yii::$app->cache->flush()) {
-            Yii::$app->session->setFlash('success', 'Cache wurde geleert');
+            Yii::$app->session->addFlash('success', 'Cache wurde geleert');
         } else {
-            Yii::$app->session->setFlash('error', 'Cache konnte nicht geleert werden');
+            Yii::$app->session->addFlash('error', 'Cache konnte nicht geleert werden');
         }
         return $this->redirect(!empty(Yii::$app->request->referrer) ? Yii::$app->request->referrer : \yii\helpers\Url::to(['/backend/']));
     }

--- a/src/controllers/DefaultController.php
+++ b/src/controllers/DefaultController.php
@@ -149,6 +149,27 @@ class DefaultController extends Controller
             ]);
     }
 
+
+
+    /**
+     * flush cache
+     *
+     * if APCu is used as cache we cannot flush cache from cli command
+     * see: https://github.com/yiisoft/yii2/issues/8647
+     *
+     * @return \yii\web\Response
+     */
+    public function actionCacheFlush()
+    {
+        if (Yii::$app->cache->flush()) {
+            Yii::$app->session->setFlash('success', 'Cache wurde geleert');
+        } else {
+            Yii::$app->session->setFlash('error', 'Cache konnte nicht geleert werden');
+        }
+        return $this->redirect(!empty(Yii::$app->request->referrer) ? Yii::$app->request->referrer : \yii\helpers\Url::to(['/backend/']));
+    }
+
+
     /**
      * @param array $item \dmstr\modules\pages\models\Tree::getMenuItems()
      *


### PR DESCRIPTION
If APCu is used as cache we cannot flush cache from cli command. apcu_clear_cache() must be called in web/fpm context. see: https://github.com/yiisoft/yii2/issues/8647

Therefore i added this backend action to be able to flush cache e.g when translations has changed
