### PR TITLE
fix language switcher to keep query parameters

### DIFF
--- a/src/views/layouts/main.php
+++ b/src/views/layouts/main.php
@@ -196,7 +196,7 @@ try {
                                             <li>
                                                 <?= Html::a(
                                                     $language,
-                                                    ['', Yii::$app->urlManager->languageParam => $language]
+                                                    Url::current([Yii::$app->urlManager->languageParam => $language])
                                                 ) ?>
                                             </li>
                                         <?php endforeach; ?>


### PR DESCRIPTION
current implementation will reuse the existing route, but will drop all query parameters, e.g. `de/widget/view?id=5` would generate `en/widget/view` instead of `en/widget/view?id=5` when switching to english.

@schmunk42 