### PR TITLE
Toolbar Fix

### DIFF
--- a/src/assets/modal/js/modal.js
+++ b/src/assets/modal/js/modal.js
@@ -2,7 +2,7 @@
 // - only when focus is on <body>, to avoid unwanted keyboard actions
 
 $(document).on("keypress", function (e) {
-  if ($(document.activeElement).is('body')) {
+  if ($(document.activeElement).is('body') && e.originalEvent.repeat !== true) {
 // open menu (m)
     if (e.charCode === 109) {
       $('#phd-info-button a').click();


### PR DESCRIPTION
Deactivation of multiple execution when key is held down.

Currently the side navigation is repeatedly faded in and out when the respective keys are held down.

The fix prevents this by checking if the key is held instead of pressed.