### PR TITLE
Prevent error if there are no backend pages

### DIFF
--- a/src/widgets/views/modal.twig
+++ b/src/widgets/views/modal.twig
@@ -3,9 +3,7 @@
 {{ use ('rmrevin/yii/fontawesome/FA') }}
 {{ use ('dmstr/lajax/translatemanager/widgets/ToggleTranslateLink') }}
 
-{% set backendItems = Tree.getMenuItems('backend', true, {'target': app.params['backend.iframe.name']} ) %}
-
-
+{% set backendItems = Tree.getMenuItems('backend', true, {'target': app.params['backend.iframe.name']} ) ?: [] %}
 
 {% if not app.user.isGuest %}
 


### PR DESCRIPTION
An error occures (Invalid argument supplied for foreach) when there are no navbar items for the backend root node and display mode is modal 