### PR TITLE
Allow package to work without the prototype dependency

### DIFF
--- a/src/views/layouts/main.php
+++ b/src/views/layouts/main.php
@@ -123,6 +123,10 @@ if (Yii::$app->hasModule('prototype')) {
         $this->blocks['extra-content'] = '';
         Yii::$app->session->addFlash('error', $e->getMessage());
     }
+} else {
+    $this->blocks['twig-main-top'] = '';
+    $this->blocks['twig-main-bottom'] = '';
+    $this->blocks['extra-content'] = '';
 }
 ?>
 


### PR DESCRIPTION
If someone does not has the prototype module installed,  an error will be thrown because the blocks in the main layout are not set at all.